### PR TITLE
C++14 does not allow lambda expressions to be constexpr

### DIFF
--- a/include/mapbox/cheap_ruler.hpp
+++ b/include/mapbox/cheap_ruler.hpp
@@ -199,9 +199,9 @@ public:
     // points on the line).
     //
     line_string lineSlice(point start, point stop, const line_string& line) {
-        constexpr auto getPoint = [](auto tuple) { return std::get<0>(tuple); };
-        constexpr auto getIndex = [](auto tuple) { return std::get<1>(tuple); };
-        constexpr auto getT     = [](auto tuple) { return std::get<2>(tuple); };
+        auto getPoint = [](auto tuple) { return std::get<0>(tuple); };
+        auto getIndex = [](auto tuple) { return std::get<1>(tuple); };
+        auto getT     = [](auto tuple) { return std::get<2>(tuple); };
 
         auto p1 = _pointOnLine(line, start);
         auto p2 = _pointOnLine(line, stop);


### PR DESCRIPTION
This breaks Mapbox GL Native CI's clang-tidy check:

> ../../../mason_packages/headers/cheap-ruler/2.5.0/include/mapbox/cheap_ruler.hpp:202:35: error: constexpr variable 'getPoint' must be initialized by a constant expression [clang-diagnostic-error]
        constexpr auto getPoint = [](auto tuple) { return std::get<0>(tuple); };
                                  ^
../../../mason_packages/headers/cheap-ruler/2.5.0/include/mapbox/cheap_ruler.hpp:203:35: error: constexpr variable 'getIndex' must be initialized by a constant expression [clang-diagnostic-error]
        constexpr auto getIndex = [](auto tuple) { return std::get<1>(tuple); };
                                  ^
../../../mason_packages/headers/cheap-ruler/2.5.0/include/mapbox/cheap_ruler.hpp:204:35: error: constexpr variable 'getT' must be initialized by a constant expression [clang-diagnostic-error]
        constexpr auto getT     = [](auto tuple) { return std::get<2>(tuple); };
                                  ^