### PR TITLE
Fix for points straddling the international date line

### DIFF
--- a/include/mapbox/cheap_ruler.hpp
+++ b/include/mapbox/cheap_ruler.hpp
@@ -86,7 +86,7 @@ public:
     // Given two points of the form [x = longitude, y = latitude], returns the distance.
     //
     double distance(point a, point b) {
-        auto dx = long_diff(a.x, b.x) * kx;
+        auto dx = longDiff(a.x, b.x) * kx;
         auto dy = (a.y - b.y) * ky;
 
         // Equivalent to (but faster than) std::hypot(dx, dy)
@@ -97,7 +97,7 @@ public:
     // Returns the bearing between two points in angles.
     //
     double bearing(point a, point b) {
-        auto dx = long_diff(b.x, a.x) * kx;
+        auto dx = longDiff(b.x, a.x) * kx;
         auto dy = (b.y - a.y) * ky;
 
         return std::atan2(dx, dy) * 180. / M_PI;
@@ -143,7 +143,7 @@ public:
             auto& ring = poly[i];
 
             for (unsigned j = 0, len = ring.size(), k = len - 1; j < len; k = j++) {
-                sum += long_diff(ring[j].x, ring[k].x) *
+                sum += longDiff(ring[j].x, ring[k].x) *
                   (ring[j].y + ring[k].y) * (i ? -1. : 1.);
             }
         }
@@ -189,11 +189,11 @@ public:
             auto t = 0.;
             auto x = line[i].x;
             auto y = line[i].y;
-            auto dx = long_diff(line[i + 1].x, x) * kx;
+            auto dx = longDiff(line[i + 1].x, x) * kx;
             auto dy = (line[i + 1].y - y) * ky;
 
             if (dx != 0. || dy != 0.) {
-                t = (long_diff(p.x, x) * kx * dx +
+                t = (longDiff(p.x, x) * kx * dx +
                      (p.y - y) * ky * dy) / (dx * dx + dy * dy);
                 if (t > 1) {
                     x = line[i + 1].x;
@@ -205,7 +205,7 @@ public:
                 }
             }
 
-            dx = long_diff(p.x, x) * kx;
+            dx = longDiff(p.x, x) * kx;
             dy = (p.y - y) * ky;
 
             auto sqDist = dx * dx + dy * dy;
@@ -326,12 +326,12 @@ public:
     bool insideBBox(point p, box bbox) {
         return p.y >= bbox.min.y &&
                p.y <= bbox.max.y &&
-               long_diff(p.x, bbox.min.x) >= 0 &&
-               long_diff(p.x, bbox.max.x) <= 0;
+               longDiff(p.x, bbox.min.x) >= 0 &&
+               longDiff(p.x, bbox.max.x) <= 0;
     }
 
     static point interpolate(point a, point b, double t) {
-        double dx = long_diff(b.x, a.x);
+        double dx = longDiff(b.x, a.x);
         double dy = b.y - a.y;
 
         return point(a.x + dx * t, a.y + dy * t);
@@ -340,7 +340,7 @@ public:
 private:
     double ky;
     double kx;
-    static double long_diff(double a, double b) {
+    static double longDiff(double a, double b) {
         return std::remainder(a - b, 360);
     }
 };

--- a/include/mapbox/cheap_ruler.hpp
+++ b/include/mapbox/cheap_ruler.hpp
@@ -86,7 +86,7 @@ public:
     // Given two points of the form [x = longitude, y = latitude], returns the distance.
     //
     double distance(point a, point b) {
-        auto dx = std::remainder(a.x - b.x, 360) * kx;
+        auto dx = long_diff(a.x, b.x) * kx;
         auto dy = (a.y - b.y) * ky;
 
         // Equivalent to (but faster than) std::hypot(dx, dy)
@@ -97,7 +97,7 @@ public:
     // Returns the bearing between two points in angles.
     //
     double bearing(point a, point b) {
-        auto dx = std::remainder(b.x - a.x, 360) * kx;
+        auto dx = long_diff(b.x, a.x) * kx;
         auto dy = (b.y - a.y) * ky;
 
         return std::atan2(dx, dy) * 180. / M_PI;
@@ -143,7 +143,7 @@ public:
             auto& ring = poly[i];
 
             for (unsigned j = 0, len = ring.size(), k = len - 1; j < len; k = j++) {
-                sum += std::remainder(ring[j].x - ring[k].x, 360) *
+                sum += long_diff(ring[j].x, ring[k].x) *
                   (ring[j].y + ring[k].y) * (i ? -1. : 1.);
             }
         }
@@ -189,11 +189,11 @@ public:
             auto t = 0.;
             auto x = line[i].x;
             auto y = line[i].y;
-            auto dx = std::remainder(line[i + 1].x - x, 360) * kx;
+            auto dx = long_diff(line[i + 1].x, x) * kx;
             auto dy = (line[i + 1].y - y) * ky;
 
             if (dx != 0. || dy != 0.) {
-                t = (std::remainder(p.x - x, 360) * kx * dx +
+                t = (long_diff(p.x, x) * kx * dx +
                      (p.y - y) * ky * dy) / (dx * dx + dy * dy);
                 if (t > 1) {
                     x = line[i + 1].x;
@@ -205,7 +205,7 @@ public:
                 }
             }
 
-            dx = std::remainder(p.x - x, 360) * kx;
+            dx = long_diff(p.x, x) * kx;
             dy = (p.y - y) * ky;
 
             auto sqDist = dx * dx + dy * dy;
@@ -326,12 +326,12 @@ public:
     bool insideBBox(point p, box bbox) {
         return p.y >= bbox.min.y &&
                p.y <= bbox.max.y &&
-               std::remainder(p.x - bbox.min.x, 360) >= 0 &&
-               std::remainder(p.x - bbox.max.x, 360) <= 0;
+               long_diff(p.x, bbox.min.x) >= 0 &&
+               long_diff(p.x, bbox.max.x) <= 0;
     }
 
     static point interpolate(point a, point b, double t) {
-        double dx = std::remainder(b.x - a.x, 360);
+        double dx = long_diff(b.x, a.x);
         double dy = b.y - a.y;
 
         return point(a.x + dx * t, a.y + dy * t);
@@ -340,6 +340,9 @@ public:
 private:
     double ky;
     double kx;
+    static double long_diff(double a, double b) {
+        return std::remainder(a - b, 360);
+    }
 };
 
 } // namespace cheap_ruler

--- a/include/mapbox/cheap_ruler.hpp
+++ b/include/mapbox/cheap_ruler.hpp
@@ -77,7 +77,7 @@ public:
 
     static CheapRuler fromTile(uint32_t y, uint32_t z) {
         double n = M_PI * (1. - 2. * (y + 0.5) / std::pow(2., z));
-        double latitude = std::atan(0.5 * (std::exp(n) - std::exp(-n))) * 180. / M_PI;
+        double latitude = std::atan(std::sinh(n)) * 180. / M_PI;
 
         return CheapRuler(latitude);
     }
@@ -86,10 +86,10 @@ public:
     // Given two points of the form [x = longitude, y = latitude], returns the distance.
     //
     double distance(point a, point b) {
-        auto dx = (a.x - b.x) * kx;
+        auto dx = std::remainder(a.x - b.x, 180) * kx;
         auto dy = (a.y - b.y) * ky;
 
-        return std::sqrt(dx * dx + dy * dy);
+        return std::hypot(dx, dy);
     }
 
     //


### PR DESCRIPTION
This fixes the distance calculation for such points by reducing the
longitude difference to the interval [-180, 180].  It also uses the
library functions sinh and hypot where appropriate.