### PR TITLE
Substitute the exact formulas for the meridional and normal curvatures.

### DIFF
--- a/include/mapbox/cheap_ruler.hpp
+++ b/include/mapbox/cheap_ruler.hpp
@@ -64,14 +64,14 @@ public:
         }
 
         // Here are the parameters (major radius in km and flattening) for the
-        // Clarke 1866 which were used to obtain the expansion parameters used
-        // in the FCC formula.
+        // Clarke 1866 ellipsoid which were used to obtain the expansion
+        // parameters used in the FCC formula.
         // These should be switched to the WGS84 parameters soon!
         // double a = 6378.137, f = 1/298.257223563;
         double a = 6378.2064, f = (a - 6356.5838) / a;
 
         auto mul = m * (M_PI / 180) * a;
-        auto cos = std::cos(latitude * M_PI / 180.);
+        auto cos = std::cos(latitude * M_PI / 180);
         auto den2 = (1-f) * (1-f) + f * (2-f) * cos * cos;
         auto den = sqrt(den2);
 
@@ -81,10 +81,10 @@ public:
         //   ky = pi/180 * M
         // where phi = latitude and from
         // https://en.wikipedia.org/wiki/Earth_radius#Principal_sections
-        //   M = meridional radius of curvature
-        //     = (a*b)^2/((a*cos(phi))^2 + (b*sin(phi))^2)^(3/2)
         //   N = normal radius of curvature
         //     = a^2/((a*cos(phi))^2 + (b*sin(phi))^2)^(1/2)
+        //   M = meridional radius of curvature
+        //     = (a*b)^2/((a*cos(phi))^2 + (b*sin(phi))^2)^(3/2)
         kx = mul * cos / den;
         ky = mul * (1-f) * (1-f) / (den * den2);
     }

--- a/include/mapbox/cheap_ruler.hpp
+++ b/include/mapbox/cheap_ruler.hpp
@@ -63,16 +63,30 @@ public:
             break;
         }
 
+        // Here are the parameters (major radius in km and flattening) for the
+        // Clarke 1866 which were used to obtain the expansion parameters used
+        // in the FCC formula.
+        // These should be switched to the WGS84 parameters soon!
+        // double a = 6378.137, f = 1/298.257223563;
+        double a = 6378.2064, f = (a - 6356.5838) / a;
+
+        auto mul = m * (M_PI / 180) * a;
         auto cos = std::cos(latitude * M_PI / 180.);
-        auto cos2 = 2. * cos * cos - 1.;
-        auto cos3 = 2. * cos * cos2 - cos;
-        auto cos4 = 2. * cos * cos3 - cos2;
-        auto cos5 = 2. * cos * cos4 - cos3;
+        auto den2 = (1-f) * (1-f) + f * (2-f) * cos * cos;
+        auto den = sqrt(den2);
 
         // multipliers for converting longitude and latitude
-        // degrees into distance (http://1.usa.gov/1Wb1bv7)
-        kx = m * (111.41513 * cos - 0.09455 * cos3 + 0.00012 * cos5);
-        ky = m * (111.13209 - 0.56605 * cos2 + 0.0012 * cos4);
+        // degrees into distance
+        //   kx = pi/180 * N * cos(phi)
+        //   ky = pi/180 * M
+        // where phi = latitude and from
+        // https://en.wikipedia.org/wiki/Earth_radius#Principal_sections
+        //   M = meridional radius of curvature
+        //     = (a*b)^2/((a*cos(phi))^2 + (b*sin(phi))^2)^(3/2)
+        //   N = normal radius of curvature
+        //     = a^2/((a*cos(phi))^2 + (b*sin(phi))^2)^(1/2)
+        kx = mul * cos / den;
+        ky = mul * (1-f) * (1-f) / (den * den2);
     }
 
     static CheapRuler fromTile(uint32_t y, uint32_t z) {

--- a/test/cheap_ruler.cpp
+++ b/test/cheap_ruler.cpp
@@ -110,9 +110,10 @@ TEST_F(CheapRulerTest, pointOnLine) {
     cr::line_string line = {{ -77.031669, 38.878605 }, { -77.029609, 38.881946 }};
     auto result = ruler.pointOnLine(line, { -77.034076, 38.882017 });
 
-    ASSERT_EQ(std::get<0>(result), cr::point(-77.03052697027461, 38.880457194811896)); // point
+    assertErr(std::get<0>(result).x, -77.03052697027461, 1e-6);
+    assertErr(std::get<0>(result).y, 38.880457194811896, 1e-6);
     ASSERT_EQ(std::get<1>(result), 0u); // index
-    ASSERT_EQ(std::get<2>(result), 0.5543833618360235); // t
+    assertErr(std::get<2>(result), 0.5543833618360235, 1e-6); // t
 
     ASSERT_EQ(std::get<2>(ruler.pointOnLine(line, { -80., 38. })), 0.) << "t is not less than 0";
     ASSERT_EQ(std::get<2>(ruler.pointOnLine(line, { -75., 38. })), 1.) << "t is not bigger than 1";
@@ -154,7 +155,7 @@ TEST_F(CheapRulerTest, lineSliceReverse) {
     auto stop = ruler.along(line, dist * 0.3);
     auto actual = ruler.lineDistance(ruler.lineSlice(start, stop, line));
 
-    ASSERT_EQ(actual, 0.018676802802910702);
+    assertErr(actual, 0.018676802802910702, 1e-6);
 }
 
 TEST_F(CheapRulerTest, bufferPoint) {
@@ -173,7 +174,10 @@ TEST_F(CheapRulerTest, bufferBBox) {
     cr::box bbox({ 30, 38 }, { 40, 39 });
     cr::box bbox2 = ruler.bufferBBox(bbox, 1);
 
-    ASSERT_EQ(bbox2, cr::box({ 29.989319515875376, 37.99098271225711 }, { 40.01068048412462, 39.00901728774289 }));
+    assertErr(bbox2.min.x,  29.989319515875376, 1e-6);
+    assertErr(bbox2.min.y,  37.99098271225711, 1e-6);
+    assertErr(bbox2.max.x,  40.01068048412462, 1e-6);
+    assertErr(bbox2.max.y,  39.00901728774289, 1e-6);
 }
 
 TEST_F(CheapRulerTest, insideBBox) {


### PR DESCRIPTION
The FCC formulas have a few drawbacks:

* They involve "magic constants" (given with a limited number of significant digits) with no indication of where they come from.
* They are based on the Clarke ellipsoid dating back to 1866 so are inconsistent with most modern GIS systems which use the WGS84 ellipsoid.
* They are written as truncated trigonometric series.  There's absolutely no reason not to use the exact expressions (which are simpler!).  (Expanding the exact expressions was traditionally done in order to perform integration leading to a series approximation of the elliptic integral.  But that's not an issues here.

Because these latitude and longitude coefficients are now exact, several tests (based on the series approximation) now fail.  I've left in place the Clarke 1866 parameters.  I recommend that the WGS84 parameters be substituted in the process of updating the tests.

I realize that cheap-ruler is already approximate, so why quibble about the coefficients?  Two reasons:

* The new formulas are accurate in limit of small distance.
* 50 years from now, no-one will be able to figure out what the old formulas mean.