### PR TITLE
Introduce point to line segment distance calculation

### DIFF
--- a/include/mapbox/cheap_ruler.hpp
+++ b/include/mapbox/cheap_ruler.hpp
@@ -194,6 +194,29 @@ public:
     }
 
     //
+    // Returns the distance from a point `p` to a line segment `a` to `b`.
+    //
+  double pointToSegmentDistance(const point& p, const point& a, const point& b) const {
+        auto t = 0.0;
+        auto x = a.x;
+        auto y = a.y;
+        auto dx = longDiff(b.x, x) * kx;
+        auto dy = (b.y - y) * ky;
+
+        if (dx != 0.0 || dy != 0.0) {
+            t = (longDiff(p.x, x) * kx * dx + (p.y - y) * ky * dy) / (dx * dx + dy * dy);
+            if (t > 1.0) {
+                x = b.x;
+                y = b.y;
+            } else if (t > 0.0) {
+                x += (dx / kx) * t;
+                y += (dy / ky) * t;
+            }
+        }
+        return distance(p, { x, y });
+    }
+
+    //
     // Returns a tuple of the form <point, index, t> where point is closest point on the line
     // from the given point, index is the start index of the segment with the closest point,
     // and t is a parameter from 0 to 1 that indicates where the closest point is on that segment.

--- a/test/cheap_ruler.cpp
+++ b/test/cheap_ruler.cpp
@@ -137,6 +137,14 @@ TEST_F(CheapRulerTest, pointOnLine) {
     ASSERT_EQ(std::get<2>(ruler.pointOnLine(line, { -75., 38. })), 1.) << "t is not bigger than 1";
 }
 
+TEST_F(CheapRulerTest, pointToSegmentDistance) {
+    cr::point p{ -77.034076, 38.882017 };
+    cr::point p0{ -77.031669, 38.878605 };
+    cr::point p1{ -77.029609, 38.881946 };
+    const auto distance = ruler.pointToSegmentDistance(p, p0, p1);
+    assertErr(0.37461484020420416, distance, 1e-6);
+}
+
 TEST_F(CheapRulerTest, lineSlice) {
     for (unsigned i = 0; i < lines.size(); ++i) {
         auto line = lines[i];


### PR DESCRIPTION
This pr introduces a new function `pointToSegmentDistance` for helping calculation of the shortest distance from a point to a line segment.